### PR TITLE
Removing the ref to a photo of dunnottar castle

### DIFF
--- a/app/Http/Controllers/EventsPagesController.php
+++ b/app/Http/Controllers/EventsPagesController.php
@@ -61,8 +61,7 @@ class EventsPagesController extends Controller
 	    return view('pages.events', [
 	        'title'=>"PHP Events In Scotland",
 	        'tagline'=>"What's going on in the PHP Community.",
-	        'events'=> $events,
-	        'image'=>'/images/random_header_images/dunnottar-castle_01.jpg'
+	        'events'=> $events
 	    ]);
 
 	}


### PR DESCRIPTION
The image referenced ...
/images/random_header_images/dunnottar-castle_01.jpg
...is not on the server any more.  The image was removed as part of issue #17.  

This was causing https://aberdeenphp.co.uk/events/php to have a header image css ref that was just going to a 404.   

This change just means it'll get a random image.