### PR TITLE
fixing the case of variable name

### DIFF
--- a/config/site.php
+++ b/config/site.php
@@ -10,7 +10,7 @@ return [
 		'ourMailingListUrl'=>'http://us10.campaign-archive2.com/home/?u=20b87746549994300f14bd083&id=509b586b54',
 		'ourGitHubUrl'=>'https://github.com/AberdeenPHP',
 		'ourContributionGuideUrl'=>'https://github.com/AberdeenPHP/AberdeenPHP-Website/blob/master/readme.md',
-		'scotlandPHPurl'=>'https://www.scotlandphp.co.uk/',
+		'scotlandPHPUrl'=>'https://www.scotlandphp.co.uk/',
 		'dannyContactHandle'=>'@iamdannywilson',
 		'dannyContactUrl'=>'https://twitter.com/iamdannywilson'
 


### PR DESCRIPTION
Just changing "scotlandPHPurl" to "scotlandPHPUrl".
It was coming through on the about page as null/unset due to the case of the U being wrong in here.

site.scotlandPHPUrl is used on...
resources/views/layouts/main.blade.php:159
resources/views/pages/about.blade.php:29